### PR TITLE
fix: matching schema changes for 1.6 to move standards to definitions…

### DIFF
--- a/standards/NIST_SSDF/nist_secure-software-development-framework_1.1.cdx.json
+++ b/standards/NIST_SSDF/nist_secure-software-development-framework_1.1.cdx.json
@@ -1,7 +1,7 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:bd6b4d9e-6f83-4801-bddc-528a54145238",
+  "serialNumber": "urn:uuid:fe247348-f2cd-4d20-b943-bd4b0772e385",
   "version": 1,
   "metadata": {
     "licenses": [
@@ -30,7 +30,7 @@
       ]
     }
   },
-  "declarations": {
+  "definitions": {
     "standards": [
       {
         "bom-ref": "ssdf-1.1",

--- a/tools/nist-ssdf-standard-generation/attestation_generator/templates/ssdf-1.1.json.template
+++ b/tools/nist-ssdf-standard-generation/attestation_generator/templates/ssdf-1.1.json.template
@@ -30,7 +30,7 @@
       ]
     }
   },
-  "declarations": {
+  "definitions": {
     "standards": [
       {
         "bom-ref": "{{standard.identifier}}",


### PR DESCRIPTION
Updated SSDF standard to match changes in 1.6 attestation draft schema. 

This change is to move the SSDF standards from `declarations` to `definitions`.